### PR TITLE
add getRepos call for organisations.

### DIFF
--- a/octokit.coffee
+++ b/octokit.coffee
@@ -506,6 +506,12 @@ makeOctokit = (_, jQuery, base64encode, userAgent) =>
             _request 'POST', "/orgs/#{@name}/repos", options
 
 
+          # List repos for an organisation
+          # -------
+          @getRepos = () ->
+            _request 'GET', "/orgs/#{@name}/repos?type=all", null
+
+
       # Repository API
       # =======
 

--- a/octokit.js
+++ b/octokit.js
@@ -470,6 +470,9 @@
               options.name = name;
               return _request('POST', "/orgs/" + this.name + "/repos", options);
             };
+            this.getRepos = function() {
+              return _request('GET', "/orgs/" + this.name + "/repos?type=all", null);
+            };
           }
 
           return Organization;


### PR DESCRIPTION
After I added this call, I noticed that something like it exists: getOrgRepos.

I decided I'll send the pull request anyway, as I'm certain more people would expect a getRepos method on the organisation object, since this mirrors both the way it works for users, and the way it works in the API.
