### PR TITLE
Add more options to the getRepos method

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,10 +292,11 @@ user.getInfo()
 .fail(function(err) {});
 ```
 
-List public repositories for a particular user.
+List public repositories for a particular user.    
+_options described [here](http://developer.github.com/v3/repos/#list-user-repositories)_
 
 ```js
-user.getRepos()
+user.getRepos(type='all', sort='pushed', direction='desc')
 .done(function(repos) {});
 ```
 

--- a/octokit.coffee
+++ b/octokit.coffee
@@ -290,8 +290,8 @@ makeOctokit = (_, jQuery, base64encode, userAgent) =>
 
           # List user repositories
           # -------
-          @getRepos = () ->
-            _request 'GET', "#{_rootPath}/repos?type=all&per_page=1000&sort=updated", null
+          @getRepos = (type='all', sort='pushed', direction='desc') ->
+            _request 'GET', "#{_rootPath}/repos?type=#{type}&per_page=1000&sort=#{sort}&direction=#{direction}", null
 
           # List user organizations
           # -------

--- a/octokit.js
+++ b/octokit.js
@@ -277,8 +277,17 @@
                 return _cachedInfo = info;
               });
             };
-            this.getRepos = function() {
-              return _request('GET', "" + _rootPath + "/repos?type=all&per_page=1000&sort=updated", null);
+            this.getRepos = function(type, sort, direction) {
+              if (type == null) {
+                type = 'all';
+              }
+              if (sort == null) {
+                sort = 'pushed';
+              }
+              if (direction == null) {
+                direction = 'desc';
+              }
+              return _request('GET', "" + _rootPath + "/repos?type=" + type + "&per_page=1000&sort=" + sort + "&direction=" + direction, null);
             };
             this.getOrgs = function() {
               return _request('GET', "" + _rootPath + "/orgs", null);


### PR DESCRIPTION
Github has a bunch of options that can be passed to `getRepos`, none of which are included here. This adds most of them. The default was also changed from `updated` to `pushed` as this reflects more accurately which ones had the latest activity and in addition mirrors how github itself sorts repos.

I'm sure there are more methods that could take options here too, if I find any more will patch in.

Also thank you so much for this amazing library. This has entirely saved our lives, and if you are on twitter let me know so I can send you a dogecoin tip my friend.
