### PR TITLE
Rename master_branch field to default_branch.

### DIFF
--- a/octokit.coffee
+++ b/octokit.coffee
@@ -1068,7 +1068,7 @@ makeOctokit = (jQuery, base64encode, userAgent) =>
             getRef = =>
               @getInfo()
               .then (info) =>
-                return info.master_branch
+                return info.default_branch
             new Branch(@git, getRef)
 
 

--- a/octokit.js
+++ b/octokit.js
@@ -991,7 +991,7 @@
                 _this = this;
               getRef = function() {
                 return _this.getInfo().then(function(info) {
-                  return info.master_branch;
+                  return info.default_branch;
                 });
               };
               return new Branch(this.git, getRef);

--- a/test/common.coffee
+++ b/test/common.coffee
@@ -116,7 +116,7 @@ makeTests = (assert, expect, btoa, Octokit) ->
               initialCommit = commits[commits.length-1]
               sha = initialCommit.sha
 
-              masterBranch = repoInfo.master_branch
+              masterBranch = repoInfo.default_branch
               console.log('BEFORE: Found master branch')
               console.log("BEFORE: Updating #{masterBranch} to #{sha}")
               trapFail(STATE[REPO].git.updateHead(masterBranch, sha, true)) # true == force


### PR DESCRIPTION
It appears github deprecated the former. For a long time they supported both fields, but as of this afternoon it fails for me.
