### PR TITLE
Remove trailing whitespace.

### DIFF
--- a/octokit.coffee
+++ b/octokit.coffee
@@ -571,7 +571,7 @@ makeOctokit = (newPromise, allPromises, XMLHttpRequest, base64encode, userAgent)
           @createRepo = (name, options={}) ->
             options.name = name
             _request 'POST', "/user/repos", options
-            
+
           # Get Received events for this authenticated user
           # -------
           @getReceivedEvents = (username, page = 1) ->


### PR DESCRIPTION
Looks bright red on my Vim =(

BTW: when compiling coffeescript with either `grunt` or `coffee octokit.js`, the banner on the js output:

```
// Generated by CoffeeScript 1.6.3
```

was been removed.

I artificially left it there by `git add` only on the coffee, but if you reproduce we should do something about it.
