### PR TITLE
[WIP][refactor] Attach methods to prototype instead of object.

### DIFF
--- a/octokit.coffee
+++ b/octokit.coffee
@@ -1071,241 +1071,241 @@ makeOctokit = (newPromise, allPromises, XMLHttpRequest, base64encode, userAgent)
 
         constructor: (@options) ->
           # Private fields
-          _user = @options.user
-          _repo = @options.name
+          @user = @options.user
+          @repo = @options.name
 
           # Set the `git` instance variable
-          @git = new GitRepo(_user, _repo)
-          @repoPath = "/repos/#{_user}/#{_repo}"
+          @git = new GitRepo(@user, @repo)
+          @repoPath = "/repos/#{@user}/#{@repo}"
           @currentTree =
             branch: null
             sha: null
 
 
-          @updateInfo = (options) ->
-            _request 'PATCH', @repoPath, options
+        updateInfo: (options) ->
+          _request 'PATCH', @repoPath, options
 
 
-          # List all branches of a repository
-          # -------
-          @getBranches = () -> @git.getBranches()
+        # List all branches of a repository
+        # -------
+        getBranches: () -> @git.getBranches()
 
 
-          # Get a branch of a repository
-          # -------
-          @getBranch = (branchName=null) ->
-            if branchName
-              getRef = () =>
-                return resolvedPromise(branchName)
-              return new Branch(@git, getRef)
-            else
-              return @getDefaultBranch()
+        # Get a branch of a repository
+        # -------
+        getBranch: (branchName=null) ->
+          if branchName
+            getRef = () =>
+              return resolvedPromise(branchName)
+            return new Branch(@git, getRef)
+          else
+            return @getDefaultBranch()
 
 
-          # Get the default branch of a repository
-          # -------
-          @getDefaultBranch = () ->
-            # Calls getInfo() to get the default branch name
-            getRef = =>
-              @getInfo()
-              .then (info) =>
-                return info.default_branch
-            new Branch(@git, getRef)
+        # Get the default branch of a repository
+        # -------
+        getDefaultBranch: () ->
+          # Calls getInfo() to get the default branch name
+          getRef = =>
+            @getInfo()
+            .then (info) =>
+              return info.default_branch
+          new Branch(@git, getRef)
 
 
-          @setDefaultBranch = (branchName) ->
-            @updateInfo {name: _repo, default_branch: branchName}
+        setDefaultBranch: (branchName) ->
+          @updateInfo {name: @repo, default_branch: branchName}
 
 
-          # Get repository information
-          # -------
-          @getInfo = () ->
-            _request 'GET', @repoPath, null
+        # Get repository information
+        # -------
+        getInfo: () ->
+          _request 'GET', @repoPath, null
 
-          # Get contents
-          # --------
-          @getContents = (branch, path) ->
-            _request 'GET', "#{@repoPath}/contents?ref=#{branch}", {path: path}
-
-
-          # Fork repository
-          # -------
-          @fork = (organization) ->
-            if organization
-              _request 'POST', "#{@repoPath}/forks",
-                organization: organization
-            else
-              _request 'POST', "#{@repoPath}/forks", null
+        # Get contents
+        # --------
+        getContents: (branch, path) ->
+          _request 'GET', "#{@repoPath}/contents?ref=#{branch}", {path: path}
 
 
-          # Create pull request
-          # --------
-          @createPullRequest = (options) ->
-            _request 'POST', "#{@repoPath}/pulls", options
+        # Fork repository
+        # -------
+        fork: (organization) ->
+          if organization
+            _request 'POST', "#{@repoPath}/forks",
+              organization: organization
+          else
+            _request 'POST', "#{@repoPath}/forks", null
 
 
-          # Get recent commits to the repository
-          # --------
-          # Takes an object of optional paramaters:
-          #
-          # - `path`: Only commits containing this file path will be returned
-          # - `author`: GitHub login, name, or email by which to filter by commit author
-          # - `since`: ISO 8601 date - only commits after this date will be returned
-          # - `until`: ISO 8601 date - only commits before this date will be returned
-          @getCommits = (options) ->
-            @git.getCommits(options)
+        # Create pull request
+        # --------
+        createPullRequest: (options) ->
+          _request 'POST', "#{@repoPath}/pulls", options
 
 
-          # List repository events
-          # -------
-          @getEvents = () ->
-            _request 'GET', "#{@repoPath}/events", null
-
-          # List Issue events for a Repository
-          # -------
-          @getIssueEvents = () ->
-            _request 'GET', "#{@repoPath}/issues/events", null
-
-          # List events for a network of Repositories
-          # -------
-          @getNetworkEvents = () ->
-            _request 'GET', "/networks/#{_user}/#{_repo}/events", null
+        # Get recent commits to the repository
+        # --------
+        # Takes an object of optional paramaters:
+        #
+        # - `path`: Only commits containing this file path will be returned
+        # - `author`: GitHub login, name, or email by which to filter by commit author
+        # - `since`: ISO 8601 date - only commits after this date will be returned
+        # - `until`: ISO 8601 date - only commits before this date will be returned
+        getCommits: (options) ->
+          @git.getCommits(options)
 
 
-          # List unread notifications for authenticated user
-          # -------
-          # Optional arguments:
-          #
-          # - `all`: `true` to show notifications marked as read.
-          # - `participating`: `true` to show only notifications in which
-          #   the user is directly participating or mentioned.
-          # - `since`: Optional time.
-          @getNotifications = (options={}) ->
-            # Converts a Date object to a string
-            getDate = (time) ->
-              return time.toISOString() if Date == time.constructor
-              return time
+        # List repository events
+        # -------
+        getEvents: () ->
+          _request 'GET', "#{@repoPath}/events", null
 
-            options.since = getDate(options.since) if options.since
+        # List Issue events for a Repository
+        # -------
+        getIssueEvents: () ->
+          _request 'GET', "#{@repoPath}/issues/events", null
 
-            queryString = toQueryString(options)
+        # List events for a network of Repositories
+        # -------
+        getNetworkEvents: () ->
+          _request 'GET', "/networks/#{@user}/#{@repo}/events", null
 
-            _request 'GET', "#{@repoPath}/notifications#{queryString}", null
 
-          # List Collaborators
-          # -------
-          # When authenticating as an organization owner of an
-          # organization-owned repository, all organization owners
-          # are included in the list of collaborators.
-          # Otherwise, only users with access to the repository are
-          # returned in the collaborators list.
-          @getCollaborators = () ->
-            _request 'GET', "#{@repoPath}/collaborators", null
+        # List unread notifications for authenticated user
+        # -------
+        # Optional arguments:
+        #
+        # - `all`: `true` to show notifications marked as read.
+        # - `participating`: `true` to show only notifications in which
+        #   the user is directly participating or mentioned.
+        # - `since`: Optional time.
+        getNotifications: (options={}) ->
+          # Converts a Date object to a string
+          getDate = (time) ->
+            return time.toISOString() if Date == time.constructor
+            return time
 
-          @addCollaborator = (username) ->
-            throw new Error 'BUG: username is required' if not username
-            _request 'PUT', "#{@repoPath}/collaborators/#{username}", null, {isBoolean:true}
+          options.since = getDate(options.since) if options.since
 
-          @removeCollaborator = (username) ->
-            throw new Error 'BUG: username is required' if not username
-            _request 'DELETE', "#{@repoPath}/collaborators/#{username}", null, {isBoolean:true}
+          queryString = toQueryString(options)
 
-          @isCollaborator = (username=null) ->
-            throw new Error 'BUG: username is required' if not username
-            _request 'GET', "#{@repoPath}/collaborators/#{username}", null, {isBoolean:true}
+          _request 'GET', "#{@repoPath}/notifications#{queryString}", null
 
-          # Can Collaborate
-          # -------
-          # True if the authenticated user has permission
-          # to commit to this repository.
-          @canCollaborate = () ->
-            # Short-circuit if no credentials provided
-            if not (clientOptions.password or clientOptions.token)
-              return resolvedPromise(false)
+        # List Collaborators
+        # -------
+        # When authenticating as an organization owner of an
+        # organization-owned repository, all organization owners
+        # are included in the list of collaborators.
+        # Otherwise, only users with access to the repository are
+        # returned in the collaborators list.
+        getCollaborators: () ->
+          _request 'GET', "#{@repoPath}/collaborators", null
 
-            _client.getLogin()
-            .then (login) =>
-              if not login
-                return false
-              else
-                return @isCollaborator(login)
-            .then null, (err) =>
-              # Problem logging in (maybe bad username/password)
+        addCollaborator: (username) ->
+          throw new Error 'BUG: username is required' if not username
+          _request 'PUT', "#{@repoPath}/collaborators/#{username}", null, {isBoolean:true}
+
+        removeCollaborator: (username) ->
+          throw new Error 'BUG: username is required' if not username
+          _request 'DELETE', "#{@repoPath}/collaborators/#{username}", null, {isBoolean:true}
+
+        isCollaborator: (username=null) ->
+          throw new Error 'BUG: username is required' if not username
+          _request 'GET', "#{@repoPath}/collaborators/#{username}", null, {isBoolean:true}
+
+        # Can Collaborate
+        # -------
+        # True if the authenticated user has permission
+        # to commit to this repository.
+        canCollaborate: () ->
+          # Short-circuit if no credentials provided
+          if not (clientOptions.password or clientOptions.token)
+            return resolvedPromise(false)
+
+          _client.getLogin()
+          .then (login) =>
+            if not login
               return false
+            else
+              return @isCollaborator(login)
+          .then null, (err) =>
+          # Problem logging in (maybe bad username/password)
+            return false
 
 
-          # List all hooks
-          # -------
-          @getHooks = () ->
-            _request 'GET', "#{@repoPath}/hooks", null
+        # List all hooks
+        # -------
+        getHooks: () ->
+          _request 'GET', "#{@repoPath}/hooks", null
 
-          # Get single hook
-          # -------
-          @getHook = (id) ->
-            _request 'GET', "#{@repoPath}/hooks/#{id}", null
+        # Get single hook
+        # -------
+        getHook: (id) ->
+          _request 'GET', "#{@repoPath}/hooks/#{id}", null
 
-          # Create a new hook
-          # -------
-          #
-          # - `name` (Required string) : The name of the service that is being called.
-          #         (See /hooks for the list of valid hook names.)
-          # - `config` (Required hash) : A Hash containing key/value pairs to provide settings for this hook.
-          #                              These settings vary between the services and are defined in the github-services repo.
-          # - `events` (Optional array) : Determines what events the hook is triggered for. Default: ["push"].
-          # - `active` (Optional boolean) : Determines whether the hook is actually triggered on pushes.
-          @createHook = (name, config, events=['push'], active=true) ->
-            data =
-              name: name
-              config: config
-              events: events
-              active: active
+        # Create a new hook
+        # -------
+        #
+        # - `name` (Required string) : The name of the service that is being called.
+        #         (See /hooks for the list of valid hook names.)
+        # - `config` (Required hash) : A Hash containing key/value pairs to provide settings for this hook.
+        #                              These settings vary between the services and are defined in the github-services repo.
+        # - `events` (Optional array) : Determines what events the hook is triggered for. Default: ["push"].
+        # - `active` (Optional boolean) : Determines whether the hook is actually triggered on pushes.
+        createHook: (name, config, events=['push'], active=true) ->
+          data =
+            name: name
+            config: config
+            events: events
+            active: active
 
-            _request 'POST', "#{@repoPath}/hooks", data
+          _request 'POST', "#{@repoPath}/hooks", data
 
-          # Edit a hook
-          # -------
-          #
-          # - `config` (Optional hash) : A Hash containing key/value pairs to provide settings for this hook.
-          #                      Modifying this will replace the entire config object.
-          #                      These settings vary between the services and are defined in the github-services repo.
-          # - `events` (Optional array) : Determines what events the hook is triggered for.
-          #                     This replaces the entire array of events. Default: ["push"].
-          # - `addEvents` (Optional array) : Determines a list of events to be added to the list of events that the Hook triggers for.
-          # - `removeEvents` (Optional array) : Determines a list of events to be removed from the list of events that the Hook triggers for.
-          # - `active` (Optional boolean) : Determines whether the hook is actually triggered on pushes.
-          @editHook = (id, config=null, events=null, addEvents=null, removeEvents=null, active=null) ->
-            data = {}
-            data.config = config if config != null
-            data.events = events if events != null
-            data.add_events = addEvents if addEvents != null
-            data.remove_events = removeEvents if removeEvents != null
-            data.active = active if active != null
+        # Edit a hook
+        # -------
+        #
+        # - `config` (Optional hash) : A Hash containing key/value pairs to provide settings for this hook.
+        #                      Modifying this will replace the entire config object.
+        #                      These settings vary between the services and are defined in the github-services repo.
+        # - `events` (Optional array) : Determines what events the hook is triggered for.
+        #                     This replaces the entire array of events. Default: ["push"].
+        # - `addEvents` (Optional array) : Determines a list of events to be added to the list of events that the Hook triggers for.
+        # - `removeEvents` (Optional array) : Determines a list of events to be removed from the list of events that the Hook triggers for.
+        # - `active` (Optional boolean) : Determines whether the hook is actually triggered on pushes.
+        editHook: (id, config=null, events=null, addEvents=null, removeEvents=null, active=null) ->
+          data = {}
+          data.config = config if config != null
+          data.events = events if events != null
+          data.add_events = addEvents if addEvents != null
+          data.remove_events = removeEvents if removeEvents != null
+          data.active = active if active != null
 
-            _request 'PATCH', "#{@repoPath}/hooks/#{id}", data
+          _request 'PATCH', "#{@repoPath}/hooks/#{id}", data
 
-          # Test a `push` hook
-          # -------
-          # This will trigger the hook with the latest push to the current
-          # repository if the hook is subscribed to push events.
-          # If the hook is not subscribed to push events, the server will
-          # respond with 204 but no test POST will be generated.
-          @testHook = (id) ->
-            _request 'POST', "#{@repoPath}/hooks/#{id}/tests", null
+        # Test a `push` hook
+        # -------
+        # This will trigger the hook with the latest push to the current
+        # repository if the hook is subscribed to push events.
+        # If the hook is not subscribed to push events, the server will
+        # respond with 204 but no test POST will be generated.
+        testHook: (id) ->
+          _request 'POST', "#{@repoPath}/hooks/#{id}/tests", null
 
-          # Delete a hook
-          # -------
-          @deleteHook = (id) ->
-            _request 'DELETE', "#{@repoPath}/hooks/#{id}", null
+        # Delete a hook
+        # -------
+        deleteHook: (id) ->
+          _request 'DELETE', "#{@repoPath}/hooks/#{id}", null
 
-          # List all Languages
-          # -------
-          @getLanguages = ->
-            _request 'GET', "#{@repoPath}/languages", null
+        # List all Languages
+        # -------
+        getLanguages: ->
+          _request 'GET', "#{@repoPath}/languages", null
 
-          # List all releases
-          # -------
-          @getReleases = () ->
-            _request 'GET', "#{@repoPath}/releases", null
+        # List all releases
+        # -------
+        getReleases: () ->
+          _request 'GET', "#{@repoPath}/releases", null
 
 
       # Gist API

--- a/octokit.js
+++ b/octokit.js
@@ -1025,217 +1025,243 @@
         })();
         Repository = (function() {
           function Repository(options) {
-            var _repo, _user;
             this.options = options;
-            _user = this.options.user;
-            _repo = this.options.name;
-            this.git = new GitRepo(_user, _repo);
-            this.repoPath = "/repos/" + _user + "/" + _repo;
+            this.user = this.options.user;
+            this.repo = this.options.name;
+            this.git = new GitRepo(this.user, this.repo);
+            this.repoPath = "/repos/" + this.user + "/" + this.repo;
             this.currentTree = {
               branch: null,
               sha: null
             };
-            this.updateInfo = function(options) {
-              return _request('PATCH', this.repoPath, options);
-            };
-            this.getBranches = function() {
-              return this.git.getBranches();
-            };
-            this.getBranch = function(branchName) {
-              var getRef,
-                _this = this;
-              if (branchName == null) {
-                branchName = null;
-              }
-              if (branchName) {
-                getRef = function() {
-                  return resolvedPromise(branchName);
-                };
-                return new Branch(this.git, getRef);
-              } else {
-                return this.getDefaultBranch();
-              }
-            };
-            this.getDefaultBranch = function() {
-              var getRef,
-                _this = this;
+          }
+
+          Repository.prototype.updateInfo = function(options) {
+            return _request('PATCH', this.repoPath, options);
+          };
+
+          Repository.prototype.getBranches = function() {
+            return this.git.getBranches();
+          };
+
+          Repository.prototype.getBranch = function(branchName) {
+            var getRef,
+              _this = this;
+            if (branchName == null) {
+              branchName = null;
+            }
+            if (branchName) {
               getRef = function() {
-                return _this.getInfo().then(function(info) {
-                  return info.default_branch;
-                });
+                return resolvedPromise(branchName);
               };
               return new Branch(this.git, getRef);
-            };
-            this.setDefaultBranch = function(branchName) {
-              return this.updateInfo({
-                name: _repo,
-                default_branch: branchName
+            } else {
+              return this.getDefaultBranch();
+            }
+          };
+
+          Repository.prototype.getDefaultBranch = function() {
+            var getRef,
+              _this = this;
+            getRef = function() {
+              return _this.getInfo().then(function(info) {
+                return info.default_branch;
               });
             };
-            this.getInfo = function() {
-              return _request('GET', this.repoPath, null);
-            };
-            this.getContents = function(branch, path) {
-              return _request('GET', "" + this.repoPath + "/contents?ref=" + branch, {
-                path: path
+            return new Branch(this.git, getRef);
+          };
+
+          Repository.prototype.setDefaultBranch = function(branchName) {
+            return this.updateInfo({
+              name: this.repo,
+              default_branch: branchName
+            });
+          };
+
+          Repository.prototype.getInfo = function() {
+            return _request('GET', this.repoPath, null);
+          };
+
+          Repository.prototype.getContents = function(branch, path) {
+            return _request('GET', "" + this.repoPath + "/contents?ref=" + branch, {
+              path: path
+            });
+          };
+
+          Repository.prototype.fork = function(organization) {
+            if (organization) {
+              return _request('POST', "" + this.repoPath + "/forks", {
+                organization: organization
               });
-            };
-            this.fork = function(organization) {
-              if (organization) {
-                return _request('POST', "" + this.repoPath + "/forks", {
-                  organization: organization
-                });
-              } else {
-                return _request('POST', "" + this.repoPath + "/forks", null);
+            } else {
+              return _request('POST', "" + this.repoPath + "/forks", null);
+            }
+          };
+
+          Repository.prototype.createPullRequest = function(options) {
+            return _request('POST', "" + this.repoPath + "/pulls", options);
+          };
+
+          Repository.prototype.getCommits = function(options) {
+            return this.git.getCommits(options);
+          };
+
+          Repository.prototype.getEvents = function() {
+            return _request('GET', "" + this.repoPath + "/events", null);
+          };
+
+          Repository.prototype.getIssueEvents = function() {
+            return _request('GET', "" + this.repoPath + "/issues/events", null);
+          };
+
+          Repository.prototype.getNetworkEvents = function() {
+            return _request('GET', "/networks/" + this.user + "/" + this.repo + "/events", null);
+          };
+
+          Repository.prototype.getNotifications = function(options) {
+            var getDate, queryString;
+            if (options == null) {
+              options = {};
+            }
+            getDate = function(time) {
+              if (Date === time.constructor) {
+                return time.toISOString();
               }
+              return time;
             };
-            this.createPullRequest = function(options) {
-              return _request('POST', "" + this.repoPath + "/pulls", options);
-            };
-            this.getCommits = function(options) {
-              return this.git.getCommits(options);
-            };
-            this.getEvents = function() {
-              return _request('GET', "" + this.repoPath + "/events", null);
-            };
-            this.getIssueEvents = function() {
-              return _request('GET', "" + this.repoPath + "/issues/events", null);
-            };
-            this.getNetworkEvents = function() {
-              return _request('GET', "/networks/" + _user + "/" + _repo + "/events", null);
-            };
-            this.getNotifications = function(options) {
-              var getDate, queryString;
-              if (options == null) {
-                options = {};
-              }
-              getDate = function(time) {
-                if (Date === time.constructor) {
-                  return time.toISOString();
-                }
-                return time;
-              };
-              if (options.since) {
-                options.since = getDate(options.since);
-              }
-              queryString = toQueryString(options);
-              return _request('GET', "" + this.repoPath + "/notifications" + queryString, null);
-            };
-            this.getCollaborators = function() {
-              return _request('GET', "" + this.repoPath + "/collaborators", null);
-            };
-            this.addCollaborator = function(username) {
-              if (!username) {
-                throw new Error('BUG: username is required');
-              }
-              return _request('PUT', "" + this.repoPath + "/collaborators/" + username, null, {
-                isBoolean: true
-              });
-            };
-            this.removeCollaborator = function(username) {
-              if (!username) {
-                throw new Error('BUG: username is required');
-              }
-              return _request('DELETE', "" + this.repoPath + "/collaborators/" + username, null, {
-                isBoolean: true
-              });
-            };
-            this.isCollaborator = function(username) {
-              if (username == null) {
-                username = null;
-              }
-              if (!username) {
-                throw new Error('BUG: username is required');
-              }
-              return _request('GET', "" + this.repoPath + "/collaborators/" + username, null, {
-                isBoolean: true
-              });
-            };
-            this.canCollaborate = function() {
-              var _this = this;
-              if (!(clientOptions.password || clientOptions.token)) {
-                return resolvedPromise(false);
-              }
-              return _client.getLogin().then(function(login) {
-                if (!login) {
-                  return false;
-                } else {
-                  return _this.isCollaborator(login);
-                }
-              }).then(null, function(err) {
+            if (options.since) {
+              options.since = getDate(options.since);
+            }
+            queryString = toQueryString(options);
+            return _request('GET', "" + this.repoPath + "/notifications" + queryString, null);
+          };
+
+          Repository.prototype.getCollaborators = function() {
+            return _request('GET', "" + this.repoPath + "/collaborators", null);
+          };
+
+          Repository.prototype.addCollaborator = function(username) {
+            if (!username) {
+              throw new Error('BUG: username is required');
+            }
+            return _request('PUT', "" + this.repoPath + "/collaborators/" + username, null, {
+              isBoolean: true
+            });
+          };
+
+          Repository.prototype.removeCollaborator = function(username) {
+            if (!username) {
+              throw new Error('BUG: username is required');
+            }
+            return _request('DELETE', "" + this.repoPath + "/collaborators/" + username, null, {
+              isBoolean: true
+            });
+          };
+
+          Repository.prototype.isCollaborator = function(username) {
+            if (username == null) {
+              username = null;
+            }
+            if (!username) {
+              throw new Error('BUG: username is required');
+            }
+            return _request('GET', "" + this.repoPath + "/collaborators/" + username, null, {
+              isBoolean: true
+            });
+          };
+
+          Repository.prototype.canCollaborate = function() {
+            var _this = this;
+            if (!(clientOptions.password || clientOptions.token)) {
+              return resolvedPromise(false);
+            }
+            return _client.getLogin().then(function(login) {
+              if (!login) {
                 return false;
-              });
+              } else {
+                return _this.isCollaborator(login);
+              }
+            }).then(null, function(err) {
+              return false;
+            });
+          };
+
+          Repository.prototype.getHooks = function() {
+            return _request('GET', "" + this.repoPath + "/hooks", null);
+          };
+
+          Repository.prototype.getHook = function(id) {
+            return _request('GET', "" + this.repoPath + "/hooks/" + id, null);
+          };
+
+          Repository.prototype.createHook = function(name, config, events, active) {
+            var data;
+            if (events == null) {
+              events = ['push'];
+            }
+            if (active == null) {
+              active = true;
+            }
+            data = {
+              name: name,
+              config: config,
+              events: events,
+              active: active
             };
-            this.getHooks = function() {
-              return _request('GET', "" + this.repoPath + "/hooks", null);
-            };
-            this.getHook = function(id) {
-              return _request('GET', "" + this.repoPath + "/hooks/" + id, null);
-            };
-            this.createHook = function(name, config, events, active) {
-              var data;
-              if (events == null) {
-                events = ['push'];
-              }
-              if (active == null) {
-                active = true;
-              }
-              data = {
-                name: name,
-                config: config,
-                events: events,
-                active: active
-              };
-              return _request('POST', "" + this.repoPath + "/hooks", data);
-            };
-            this.editHook = function(id, config, events, addEvents, removeEvents, active) {
-              var data;
-              if (config == null) {
-                config = null;
-              }
-              if (events == null) {
-                events = null;
-              }
-              if (addEvents == null) {
-                addEvents = null;
-              }
-              if (removeEvents == null) {
-                removeEvents = null;
-              }
-              if (active == null) {
-                active = null;
-              }
-              data = {};
-              if (config !== null) {
-                data.config = config;
-              }
-              if (events !== null) {
-                data.events = events;
-              }
-              if (addEvents !== null) {
-                data.add_events = addEvents;
-              }
-              if (removeEvents !== null) {
-                data.remove_events = removeEvents;
-              }
-              if (active !== null) {
-                data.active = active;
-              }
-              return _request('PATCH', "" + this.repoPath + "/hooks/" + id, data);
-            };
-            this.testHook = function(id) {
-              return _request('POST', "" + this.repoPath + "/hooks/" + id + "/tests", null);
-            };
-            this.deleteHook = function(id) {
-              return _request('DELETE', "" + this.repoPath + "/hooks/" + id, null);
-            };
-            this.getLanguages = function() {
-              return _request('GET', "" + this.repoPath + "/languages", null);
-            };
-            this.getReleases = function() {
-              return _request('GET', "" + this.repoPath + "/releases", null);
-            };
-          }
+            return _request('POST', "" + this.repoPath + "/hooks", data);
+          };
+
+          Repository.prototype.editHook = function(id, config, events, addEvents, removeEvents, active) {
+            var data;
+            if (config == null) {
+              config = null;
+            }
+            if (events == null) {
+              events = null;
+            }
+            if (addEvents == null) {
+              addEvents = null;
+            }
+            if (removeEvents == null) {
+              removeEvents = null;
+            }
+            if (active == null) {
+              active = null;
+            }
+            data = {};
+            if (config !== null) {
+              data.config = config;
+            }
+            if (events !== null) {
+              data.events = events;
+            }
+            if (addEvents !== null) {
+              data.add_events = addEvents;
+            }
+            if (removeEvents !== null) {
+              data.remove_events = removeEvents;
+            }
+            if (active !== null) {
+              data.active = active;
+            }
+            return _request('PATCH', "" + this.repoPath + "/hooks/" + id, data);
+          };
+
+          Repository.prototype.testHook = function(id) {
+            return _request('POST', "" + this.repoPath + "/hooks/" + id + "/tests", null);
+          };
+
+          Repository.prototype.deleteHook = function(id) {
+            return _request('DELETE', "" + this.repoPath + "/hooks/" + id, null);
+          };
+
+          Repository.prototype.getLanguages = function() {
+            return _request('GET', "" + this.repoPath + "/languages", null);
+          };
+
+          Repository.prototype.getReleases = function() {
+            return _request('GET', "" + this.repoPath + "/releases", null);
+          };
 
           return Repository;
 


### PR DESCRIPTION
Doing:
- `@func = ->` inside of the constructor attaches methods to objects, which uses extra memory if there are multiple objects
- `func: ->` attaches to `.prototype`, so one per class.

Since it is more efficient, it is also more common, and therefore easier to identify the instance methods.

Also requires using `@user` instead of `_user` closure variable, which is good as it makes it clear what is an instance variable and what is a local one.

If good I will do this for every class.

Only the 2 currently failing tests fail like before this PR.
