### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ This requires NodeJS 0.11 with the `--harmony-generators` flag:
 ```js
 var co = require('co');
 var Octokit = require('octokit');
-var gh = Octokit.new();
+var gh = new Octokit({
+  token: "access token",
+  auth: "oauth"
+});
 
 var fn = function *() {
   var zen  = yield gh.getZen();


### PR DESCRIPTION
there is no .new method on Octokit in the browser
passively show that oauth can be used

Maybe rather just tack on the new method?
