### PR TITLE
Fix _.isArray

### DIFF
--- a/octokit.coffee
+++ b/octokit.coffee
@@ -24,8 +24,8 @@ _ = {}
 _.isEmpty = (object) ->
   Object.keys(object).length == 0
 
-_.isArray = (object) ->
-  !!object?.slice
+_.isArray = Array.isArray or (obj) ->
+  toString.call(obj) is'[object Array]'
 
 _.defaults = (object, values) ->
   for key in Object.keys(values)

--- a/octokit.js
+++ b/octokit.js
@@ -11,8 +11,8 @@
     return Object.keys(object).length === 0;
   };
 
-  _.isArray = function(object) {
-    return !!(object != null ? object.slice : void 0);
+  _.isArray = Array.isArray || function(obj) {
+    return toString.call(obj) === '[object Array]';
   };
 
   _.defaults = function(object, values) {


### PR DESCRIPTION
_.isArray implementation is broken.

```
> isArray = function (object) {
    return !!(object != null ? object.slice : void 0);}
> isArray("this")
true
> _.isArray("this") // the real underscore
false
```
